### PR TITLE
remove trailing whitespace

### DIFF
--- a/dashboard/mam_dashboard.py
+++ b/dashboard/mam_dashboard.py
@@ -52,7 +52,7 @@ def coltr(colo,t):
     if (colo == 'toto'):
       out = 'rgba'+ str(mpc.to_rgba(colo)[:3]+(t,))
     else:
-      out = colo 
+      out = colo
     return out
 tr = 0.8
 specolor = {
@@ -128,9 +128,9 @@ qhcl          = {params['qhcl']}
 def run_fortran_model(work_dir='.'):
     """Run the Fortran gcmambox executable"""
     try:
-        result = subprocess.run(['./gcmambox'], 
-                              capture_output=True, 
-                              text=True, 
+        result = subprocess.run(['./gcmambox'],
+                              capture_output=True,
+                              text=True,
                               timeout=30,
                               cwd=work_dir)
         if result.returncode != 0:
@@ -155,7 +155,7 @@ def create_animated_figure(nc_file='mam_output.nc', dt = 1200):
             x=0.5, y=0.5, showarrow=False,
             font=dict(size=20)
         )
-    
+
     frames = []
     for s in ds.nsteps:
         df = ds.sel(nsteps=s)
@@ -188,12 +188,12 @@ def create_animated_figure(nc_file='mam_output.nc', dt = 1200):
             trace = go.Scatter(
                 x=x_vol, y=ycum, fill=fil,
                 mode='none', fillcolor=specolor[c],
-                opacity=0.3, name=c 
+                opacity=0.3, name=c
             )
             data_list.append(trace)
             ntrac2 = ntrac2+1
             fil = 'tonexty'
-        
+
         # Total mass
         trace = go.Scatter(
             x=x_vol, y=ycum, mode='lines',
@@ -201,7 +201,7 @@ def create_animated_figure(nc_file='mam_output.nc', dt = 1200):
         )
         data_list.append(trace)
         ntrac2 = ntrac2+1
-# Text 
+# Text
         trace = go.Scatter(
         x=[0.005] ,
         y=[np.max(ycum)*0.6] ,
@@ -223,7 +223,7 @@ def create_animated_figure(nc_file='mam_output.nc', dt = 1200):
         mode='text',  # Show both markers and text
         text=['TEMP = %s'%round(float(df['temp']),2)],
         textposition='top left',
-        name= "  ",  
+        name= "  ",
         #        marker=dict(size=10, color='blue'),
         textfont=dict(size=16, color='red')
         )
@@ -268,15 +268,15 @@ def create_animated_figure(nc_file='mam_output.nc', dt = 1200):
 
 
         frames += [go.Frame(data=data_list, name='step%s' % s)]
-    
+
     # Create figure with subplots
     fig = go.Figure().set_subplots(3, 1,vertical_spacing=0.07)
                                    #insets=[{'cell':(2,1), 'l':0.5, 'b':0.5 , 'w' : 0.1, 'h' : 0.1}])
-#    fig = make_subplots(rows=3, cols=1, 
+#    fig = make_subplots(rows=3, cols=1,
 #                    specs=[[{'type': 'xy'}], [{'type': 'xy'}], [{'type': 'xy'}]],
 #                    vertical_spacing=0.07,
 #                    insets=[dict(cell=(1,1), l=0.55, b= 0.43, w = 0.1, h = 0.1),
-#                            dict(cell=(2,1), l=0.5, h=0.65, b=0.1,  type='polar')]) 
+#                            dict(cell=(2,1), l=0.5, h=0.65, b=0.1,  type='polar')])
     fig.add_traces(frames[0].data[0:ntrac1], 1, 1)
     fig.add_traces(frames[0].data[ntrac1:ntrac2], 2, 1)
     fig.add_traces(frames[0].data[ntrac2:ntrac3], 3, 1)
@@ -286,13 +286,13 @@ def create_animated_figure(nc_file='mam_output.nc', dt = 1200):
     # Update axes
     fig.update_xaxes(range=[-1, len(ds.nsteps)], title='time steps', row=1, col=1)
     fig.update_yaxes(type='log', range=[-1., 2], title='gas conc. (ppb)', row=1, col=1)
-    
+
     fig.update_xaxes(type="log", range=[-3, 2], title='D (microm)', row=2, col=1)
     fig.update_yaxes(range=[0, np.max(ycum)], title='aer. dm/dlogD (kg.kg-1)', row=2, col=1)
-    
+
     fig.update_xaxes(type="log", range=[-3, 2], title='D (microm)', row=3, col=1)
     fig.update_yaxes(type='log', range=[5, 11], title='aer. dN/dlogD (#.kg-1)', row=3, col=1)
-    
+
     fig.frames = frames
 
 # Animation controls
@@ -319,7 +319,7 @@ def create_animated_figure(nc_file='mam_output.nc', dt = 1200):
             for k, f in enumerate(fig.frames)
         ],
     }]
-   
+
     fig.update_layout(
         sliders=sliders,
         legend={'traceorder': 'normal','font': {'size': 18} },
@@ -357,7 +357,7 @@ def create_animated_figure(nc_file='mam_output.nc', dt = 1200):
             "yanchor": "bottom",
         }]
     )
-    
+
     return fig
 
 # ============================================================================
@@ -388,15 +388,15 @@ app = dash.Dash(__name__)
 app.layout = html.Div([
 
 #    html.Div([
-#           html.Img(src='assets/logo.png', style={'height': '130px', 'width': '600px'}),], 
+#           html.Img(src='assets/logo.png', style={'height': '130px', 'width': '600px'}),],
 #           style={'textAlign': 'center', 'marginBottom': '10px', 'padding': '10px'}),
 
 html.Div([
     html.Div(style={'flex': '1'}),  # Spacer
     html.Img(src='assets/logo.png', style={'height': '130px', 'width': '600px'}),
     html.Div([
-        html.A('📄 Doc !', 
-               href='assets/doc.pdf', 
+        html.A('📄 Doc !',
+               href='assets/doc.pdf',
                target='_blank',
                style={'padding': '16px 16px',
                       'backgroundColor': '#0066cc', 'color': 'white', 'textDecoration': 'none',
@@ -410,26 +410,26 @@ html.Div([
         html.Div([
             html.Div([
                 html.H3("Simulation Controls", style={'marginTop': '0'}),
-                
+
                 # Run button at the top
                 html.Button('Run Simulation', id='run-button', n_clicks=0,
                            style={'width': '100%', 'height': '40px', 'fontSize': '16px',
                                  'backgroundColor': '#4CAF50', 'color': 'white',
                                  'border': 'none', 'cursor': 'pointer', 'borderRadius': '5px', 'marginBottom': '10px'}),
-                
+
                 html.Div(id='status-message', style={'marginTop': '5px', 'marginBottom': '10px', 'fontWeight': 'bold', 'fontSize': '12px'}),
-                
+
                 html.Hr(style={'margin': '10px 0'}),
-                
+
                 # Time parameters
                 html.H4("Time Parameters", style={'fontSize': '16px', 'marginTop': '10px'}),
                 html.Label("Time step (s):", style={'fontSize': '12px'}),
                 dcc.Input(id='mam_dt', type='number', value=1200, style={'width': '100%', 'marginBottom': '5px'}),
                 html.Label("Number of steps:", style={'fontSize': '12px'}),
                 dcc.Input(id='mam_nstep', type='number', value=100, style={'width': '100%', 'marginBottom': '10px'}),
-                
+
                 html.Hr(style={'margin': '10px 0'}),
-                
+
                 # Process controls
                 html.H4("Process Controls", style={'fontSize': '16px', 'marginTop': '10px'}),
                 dcc.Checklist(
@@ -444,9 +444,9 @@ html.Div([
                     value=['gaschem', 'gasaerexch', 'rename', 'newnuc', 'coag'],
                     style={'fontSize': '12px'}
                 ),
-                
+
                 html.Hr(style={'margin': '10px 0'}),
-                
+
                 # Meteorology
                 html.H4("Meteorological Parameters", style={'fontSize': '16px', 'marginTop': '10px'}),
                 html.Label("Temperature Initial (K):", style={'fontSize': '12px'}),
@@ -459,9 +459,9 @@ html.Div([
                 dcc.Input(id='mrhmin', type='number', value=0.5, step=0.01, style={'width': '100%', 'marginBottom': '5px'}),
                 html.Label("Relative Humidity Final:", style={'fontSize': '12px'}),
                 dcc.Input(id='mrhmax', type='number', value=0.5, step=0.01, style={'width': '100%', 'marginBottom': '10px'}),
-                
+
                 html.Hr(style={'margin': '10px 0'}),
-                
+
                 # Gas concentrations
                 html.H4("Gas Concentrations (ppb)", style={'fontSize': '16px', 'marginTop': '10px'}),
                 html.Label("SO2:", style={'fontSize': '12px'}),
@@ -476,9 +476,9 @@ html.Div([
                 dcc.Input(id='qsoag', type='number', value=0., style={'width': '100%', 'marginBottom': '5px'}),
                 html.Label("HCl:", style={'fontSize': '12px'}),
                 dcc.Input(id='qhcl', type='number', value=0., style={'width': '100%', 'marginBottom': '10px'}),
-                
+
                 html.Hr(style={'margin': '10px 0'}),
-                
+
                 # Number concentrations
                 html.H4("Number Concentrations (#/cm³)", style={'fontSize': '16px', 'marginTop': '10px'}),
                 html.Div([
@@ -499,12 +499,12 @@ html.Div([
                         dcc.Input(id='numc-3', type='number', value=0.e5, style={'width': 'calc(100% - 55px)', 'fontSize': '11px'}),
                     ], style={'marginBottom': '10px'}),
                 ]),
-                
+
                 html.Hr(style={'margin': '10px 0'}),
-                
+
                 # Mass fractions by mode
                 html.H4("Mass Fractions by Mode", style={'fontSize': '16px', 'marginTop': '10px'}),
-                
+
                 # Mode 0
                 html.Details([
                     html.Summary("Mode 0 - Accumulation", style={'fontSize': '13px', 'fontWeight': 'bold', 'cursor': 'pointer'}),
@@ -522,7 +522,7 @@ html.Div([
                         create_mass_fraction_input("CL", 0, 0.15),
                     ], style={'paddingLeft': '10px', 'paddingTop': '5px'})
                 ], open=False, style={'marginBottom': '5px'}),
-                
+
                 # Mode 1
                 html.Details([
                     html.Summary("Mode 1 - Aitken", style={'fontSize': '13px', 'fontWeight': 'bold', 'cursor': 'pointer'}),
@@ -540,7 +540,7 @@ html.Div([
                         create_mass_fraction_input("CL", 1, 0.0),
                     ], style={'paddingLeft': '10px', 'paddingTop': '5px'})
                 ], open=False, style={'marginBottom': '5px'}),
-                
+
                 # Mode 2
                 html.Details([
                     html.Summary("Mode 2 - Coarse", style={'fontSize': '13px', 'fontWeight': 'bold', 'cursor': 'pointer'}),
@@ -558,7 +558,7 @@ html.Div([
                         create_mass_fraction_input("CL", 2, 0.6),
                     ], style={'paddingLeft': '10px', 'paddingTop': '5px'})
                 ], open=False, style={'marginBottom': '5px'}),
-                
+
                 # Mode 3
                 html.Details([
                     html.Summary("Mode 3 - Primary Carbon", style={'fontSize': '13px', 'fontWeight': 'bold', 'cursor': 'pointer'}),
@@ -576,10 +576,10 @@ html.Div([
                         create_mass_fraction_input("CL", 3, 0.0),
                     ], style={'paddingLeft': '10px', 'paddingTop': '5px'})
                 ], open=False, style={'marginBottom': '10px'}),
-                
+
             ], style={'padding': '15px', 'overflowY': 'scroll', 'height': 'calc(100vh - 130px)'})
         ], style={'width': '15%', 'backgroundColor': '#f5f5f5', 'boxSizing': 'border-box'}),
-        
+
         # Right panel - Visualization
         html.Div([
             dcc.Loading(
@@ -588,7 +588,7 @@ html.Div([
                 children=dcc.Graph(id='animation-plot', style={'height': 'calc(100vh - 160px)'})
             ),
         ], style={'width': '85%', 'padding': '10px', 'boxSizing': 'border-box', 'backgroundColor': '#e6f2ff'}),
-        
+
     ], style={'display': 'flex', 'height': 'calc(100vh - 160px)'}),
 ], style={'fontFamily': 'Arial, sans-serif', 'margin': '0', 'padding': '0', 'backgroundColor': '#e6f2ff'})
 
@@ -686,7 +686,7 @@ def run_simulation(n_clicks, mam_dt, mam_nstep, processes, mtmin,mtmax, press, m
                    mfso4_3, mfpom_3, mfsoa_3, mfbc_3, mfdst_3, mfncl_3,
                    mfno3_3, mfnh4_3, mfco3_3, mfca_3, mfcl_3):
     """Run simulation when button is clicked and update the plot"""
-    
+
     # For initial load, just create figure from existing data
     if n_clicks == 0:
         if os.path.exists('mam_output.nc'):
@@ -700,11 +700,11 @@ def run_simulation(n_clicks, mam_dt, mam_nstep, processes, mtmin,mtmax, press, m
                 font=dict(size=24)
             )
             return empty_fig, "Ready to run simulation"
-    
+
     # Create unique temporary directory for this simulation
     session_id = str(uuid.uuid4())
     temp_dir = tempfile.mkdtemp(prefix=f'mam_sim_{session_id}_')
-    
+
     try:
         # Build parameters dictionary
         params = {
@@ -741,7 +741,7 @@ def run_simulation(n_clicks, mam_dt, mam_nstep, processes, mtmin,mtmax, press, m
             'qnh3': qnh3,
             'qhcl': qhcl,
         }
-        
+
         # Copy executable to temp directory
         if os.path.exists('./gcmambox'):
             shutil.copy('./gcmambox', temp_dir)
@@ -752,14 +752,14 @@ def run_simulation(n_clicks, mam_dt, mam_nstep, processes, mtmin,mtmax, press, m
                 x=0.5, y=0.5, showarrow=False,
                 font=dict(size=20, color='red')
             ), "❌ Executable not found")
-        
+
         # Write namelist file in temp directory
         namelist_path = os.path.join(temp_dir, 'namelist')
         write_namelist(params, namelist_path)
-        
+
         # Run Fortran model in temp directory
         success, message = run_fortran_model(temp_dir)
-        
+
         if not success:
             error_fig = go.Figure().add_annotation(
                 text=f"Simulation failed: {message}",
@@ -768,22 +768,22 @@ def run_simulation(n_clicks, mam_dt, mam_nstep, processes, mtmin,mtmax, press, m
                 font=dict(size=20, color='red')
             )
             return error_fig, f"❌ {message}"
-        
+
         # Copy output file back to main directory with unique session name
         output_nc = os.path.join(temp_dir, 'mam_output.nc')
         if os.path.exists(output_nc):
             session_output = f'mam_output_{session_id}.nc'
             shutil.copy(output_nc, session_output)
-            print('mam_dt',mam_dt) 
+            print('mam_dt',mam_dt)
             # Create figure from session-specific results
             fig = create_animated_figure(session_output, dt=mam_dt)
-            
+
             # Clean up session-specific output file after creating figure
             try:
                 os.remove(session_output)
             except Exception as e:
                 print(f"Warning: Could not remove {session_output}: {e}")
-            
+
             return fig, "✅ " + message
         else:
             return (go.Figure().add_annotation(
@@ -792,7 +792,7 @@ def run_simulation(n_clicks, mam_dt, mam_nstep, processes, mtmin,mtmax, press, m
                 x=0.5, y=0.5, showarrow=False,
                 font=dict(size=20, color='red')
             ), "❌ No output generated")
-    
+
     finally:
         # Clean up temporary directory
         try:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 # Option 2: Manual search if pkg-config fails
 if(NOT NETCDF_FOUND)
     message(STATUS "Searching for NetCDF manually...")
-    
+
     # Set potential search paths
     set(NETCDF_SEARCH_PATHS
         /home/fsolmon/miniconda3
@@ -54,28 +54,28 @@ if(NOT NETCDF_FOUND)
 	$ENV{NETCDF_LIB}
         $ENV{NETCDF_FORTRAN_HOME}
     )
-    
+
     # Find NetCDF C library
     find_library(NETCDF_C_LIB
         NAMES netcdf
         PATHS ${NETCDF_SEARCH_PATHS}
         PATH_SUFFIXES lib lib64
     )
-    
+
     # Find NetCDF Fortran library
     find_library(NETCDF_F_LIB
         NAMES netcdff
         PATHS ${NETCDF_SEARCH_PATHS}
         PATH_SUFFIXES lib lib64
     )
-    
+
     # Find NetCDF include directory
     find_path(NETCDF_INCLUDE_DIR
         NAMES netcdf.mod netcdf.inc
         PATHS ${NETCDF_SEARCH_PATHS}
         PATH_SUFFIXES include Include
     )
-    
+
     if(NETCDF_C_LIB AND NETCDF_F_LIB AND NETCDF_INCLUDE_DIR)
         set(NETCDF_FOUND TRUE)
         set(NETCDF_LIBRARIES ${NETCDF_F_LIB} ${NETCDF_C_LIB})
@@ -139,7 +139,7 @@ set(EXE "gcmambox" CACHE STRING "Executable name")
 function(preprocess_fortran input_file output_file)
     get_filename_component(file_name ${input_file} NAME_WE)
     get_filename_component(file_ext ${input_file} EXT)
-    
+
     if(file_ext STREQUAL ".F" OR file_ext STREQUAL ".F90")
         # Determine output extension
         if(file_ext STREQUAL ".F")
@@ -147,16 +147,16 @@ function(preprocess_fortran input_file output_file)
         else()
             set(out_ext ".f90")
         endif()
-        
+
         set(preprocessed_file "${OUT_DIR}/${file_name}${out_ext}")
-        
+
         add_custom_command(
             OUTPUT ${preprocessed_file}
             COMMAND ${CPP} ${CPPFLAGS} ${input_file} ${preprocessed_file}
             DEPENDS ${input_file}
             COMMENT "Preprocessing ${input_file}"
         )
-        
+
         set(${output_file} ${preprocessed_file} PARENT_SCOPE)
     else()
         set(${output_file} ${input_file} PARENT_SCOPE)
@@ -166,7 +166,7 @@ endfunction()
 #-----------------------------------------------------------------------------
 # Source file lists
 # normally the OBJ1-OBJ5 are sources that are used in the MAM lib in GeosCore
-# OBJ 9 is the driver 
+# OBJ 9 is the driver
 #-----------------------------------------------------------------------------
 
 # OBJ1: Shared modules
@@ -176,7 +176,7 @@ set(OBJ1_SOURCES
     mam_utils.F90
 )
 
-# OBJ2: declaration and utilities from CAM env.  
+# OBJ2: declaration and utilities from CAM env.
 set(OBJ2_SOURCES
     constituents.F90
     radconstants.F90
@@ -218,7 +218,7 @@ set(OBJ5_SOURCES
     modal_aero_initialize_data.F90
 )
 
-# OBJ9: Driver and utilitie for box model  
+# OBJ9: Driver and utilitie for box model
 set(OBJ9_SOURCES
     gaschem_simple.F90
     cloudchem_simple.F90
@@ -245,7 +245,7 @@ set(SOURCE_SEARCH_PATHS
 set(VERIFIED_SOURCES)
 foreach(src_file ${ALL_SOURCES})
     set(found FALSE)
-    
+
     # Try each search path
     foreach(search_path ${SOURCE_SEARCH_PATHS})
         if(EXISTS "${search_path}/${src_file}")
@@ -257,7 +257,7 @@ foreach(src_file ${ALL_SOURCES})
             get_filename_component(base_name ${src_file} NAME_WE)
             get_filename_component(ext ${src_file} EXT)
             string(TOLOWER ${ext} ext_lower)
-            
+
             if(EXISTS "${search_path}/${base_name}${ext_lower}")
                 list(APPEND VERIFIED_SOURCES ${search_path}/${base_name}${ext_lower})
                 set(found TRUE)
@@ -265,7 +265,7 @@ foreach(src_file ${ALL_SOURCES})
             endif()
         endif()
     endforeach()
-    
+
     if(NOT found)
         message(WARNING "Source file not found in any search path: ${src_file}")
     endif()

--- a/src/cloudchem_simple.F90
+++ b/src/cloudchem_simple.F90
@@ -31,7 +31,7 @@ subroutine cloudchem_simple_sub(            &
 
 use mam_utils  ,       only:  iulog,pcols,pver,endrun
 use constituents,      only:  pcnst, cnst_name, cnst_get_ind
-                                                                                                                                            
+
 
 use modal_aero_data
 
@@ -52,7 +52,7 @@ implicit none
    real(r8), intent(inout) :: qqcw(ncol,pver,pcnst) ! like q but for cloud-borner tracers
    real(r8), intent(in)    :: cldn(ncol,pver)      ! cloud fraction
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 ! computes TMR (tracer mixing ratio) tendencies for gas condensation
 !    onto aerosol particles
 !

--- a/src/driver.F90
+++ b/src/driver.F90
@@ -26,12 +26,12 @@
 
 #if(defined USE_NC4)
       use netcdf
-#endif 
+#endif
       implicit none
 
       public
 
-! similaire a  GeosCore mam_driv 
+! similaire a  GeosCore mam_driv
 !      integer :: mdo_gaschem, mdo_cloudchem
 !      integer :: mdo_gasaerexch, mdo_rename, mdo_newnuc, mdo_coag
       integer:: loffset, lchnk
@@ -41,7 +41,7 @@
       type(physics_state) :: physta
       type(physics_ptend) :: ptend
 
-       
+
 
 ! propres au driver de mambox
       integer, parameter :: lun_outfld = 90
@@ -53,8 +53,8 @@
       real(r8) :: xopt_cloudf
 
       ! in the multiple nbc/npoa code, the following are in modal_aero_data
-      integer :: lptr_bca_a_amode(ntot_amode) = -999888777 
-      integer :: lptr_poma_a_amode(ntot_amode) = -999888777 
+      integer :: lptr_bca_a_amode(ntot_amode) = -999888777
+      integer :: lptr_poma_a_amode(ntot_amode) = -999888777
 
       integer :: species_class(pcnst) = -1
 
@@ -74,19 +74,19 @@
          qqcw_get_field
 
       use modal_aero_initialize_data, only: MAM_init_basics, MAM_ALLOCATE, MAM_cold_start
-      
+
       integer :: nstop
-      real*8  :: deltat 
-      
+      real*8  :: deltat
+
       pcols = 1
       pver = 1
- 
+
       plev = pver
 
 
 
 
-      masterproc = .true. 
+      masterproc = .true.
 
 
       write(*,'(/a)') '*** Hello from MAIN ***'
@@ -95,8 +95,8 @@
       call MAM_init_basics(pbuf)
       write(*,'(/a)') '*** main call MAM_allocate'
       call MAM_ALLOCATE (physta,ptend )
-     
-      call gcmambox_init_run (nstop,deltat)  
+
+      call gcmambox_init_run (nstop,deltat)
 
       write(*,'(/a)') '*** main calling cambox_do_run'
 
@@ -117,11 +117,11 @@
       use modal_aero_amicphys, only: &
            gaexch_h2so4_uptake_optaa, newnuc_h2so4_conc_optaa, mosaic
 
-      use  modal_aero_initialize_data, only: MAM_init_basics, MAM_ALLOCATE, MAM_cold_start 
-      implicit none 
+      use  modal_aero_initialize_data, only: MAM_init_basics, MAM_ALLOCATE, MAM_cold_start
+      implicit none
       integer,  intent(out  ) :: nstop
       real(r8), intent(out  ) :: deltat
-      
+
       integer :: i
       integer :: k
       integer :: l, ll, loffset, lun
@@ -174,7 +174,7 @@
 
 
 !-------------------------------------------------------------------------------
-      subroutine gcmambox_do_run( nstop, deltat) 
+      subroutine gcmambox_do_run( nstop, deltat)
 
       use chem_mods, only: adv_mass, gas_pcnst, imozart
       use physconst, only: mwdry
@@ -189,7 +189,7 @@
       use gaschem_simple, only: gaschem_simple_sub
       use cloudchem_simple, only: cloudchem_simple_sub
       use wv_saturation, only : qsat
-      implicit none 
+      implicit none
 
       integer,  intent(in   ) :: nstop
 
@@ -224,8 +224,8 @@
       logical :: aero_mmr_flag
       logical :: h2o_mmr_flag
       logical :: dotend(pcnst)
-   
-      real(r8) ::temp, relh 
+
+      real(r8) ::temp, relh
 
       real(r8) :: ev_sat(pcols,pver), qv_sat(pcols,pver)
 
@@ -235,14 +235,14 @@
       real(r8) :: dqdt(pcols,pver,pcnst)        ! Tracer MR tendency array
       real(r8) :: dvmrdt_bb(pcols,pver,gas_pcnst,nqtendbb)   ! mixing ratio changes
       real(r8) :: dvmrcwdt_bb(pcols,pver,gas_pcnst,nqqcwtendbb) ! mixing ratio changes
-      real(r8) :: dvmrdt_cond(pcols,pver,gas_pcnst)   ! mixing ratio changes from renaming 
-      real(r8) :: dvmrcwdt_cond(pcols,pver,gas_pcnst) ! mixing ratio changes from renaming 
-      real(r8) :: dvmrdt_nnuc(pcols,pver,gas_pcnst)   ! mixing ratio changes from renaming 
-      real(r8) :: dvmrcwdt_nnuc(pcols,pver,gas_pcnst) ! mixing ratio changes from renaming 
-      real(r8) :: dvmrdt_coag(pcols,pver,gas_pcnst)   ! mixing ratio changes from renaming 
-      real(r8) :: dvmrcwdt_coag(pcols,pver,gas_pcnst) ! mixing ratio changes from renaming 
-      real(r8) :: dvmrdt_rnam(pcols,pver,gas_pcnst)   ! mixing ratio changes from renaming 
-      real(r8) :: dvmrcwdt_rnam(pcols,pver,gas_pcnst) ! mixing ratio changes from renaming 
+      real(r8) :: dvmrdt_cond(pcols,pver,gas_pcnst)   ! mixing ratio changes from renaming
+      real(r8) :: dvmrcwdt_cond(pcols,pver,gas_pcnst) ! mixing ratio changes from renaming
+      real(r8) :: dvmrdt_nnuc(pcols,pver,gas_pcnst)   ! mixing ratio changes from renaming
+      real(r8) :: dvmrcwdt_nnuc(pcols,pver,gas_pcnst) ! mixing ratio changes from renaming
+      real(r8) :: dvmrdt_coag(pcols,pver,gas_pcnst)   ! mixing ratio changes from renaming
+      real(r8) :: dvmrcwdt_coag(pcols,pver,gas_pcnst) ! mixing ratio changes from renaming
+      real(r8) :: dvmrdt_rnam(pcols,pver,gas_pcnst)   ! mixing ratio changes from renaming
+      real(r8) :: dvmrcwdt_rnam(pcols,pver,gas_pcnst) ! mixing ratio changes from renaming
       real(r8) :: h2so4_pre_gaschem(pcols,pver) ! grid-avg h2so4(g) mix ratio before gas chem (mol/mol)
       real(r8) :: h2so4_aft_gaschem(pcols,pver) ! grid-avg h2so4(g) mix ratio after  gas chem (mol/mol)
       real(r8) :: h2so4_clear_avg(  pcols,pver) ! average clear sub-area h2so4(g) mix ratio (mol/mol)
@@ -274,8 +274,8 @@
       integer :: dimids(2), varid(30)
       character (8) :: date
       real(r8), dimension(nstop,ntot_amode) :: tmp_dgn_a, &
-                               tmp_dgn_awet, tmp_num_aer 
-real(r8) :: tmp_so4_aer(nstop, ntot_amode)                               
+                               tmp_dgn_awet, tmp_num_aer
+real(r8) :: tmp_so4_aer(nstop, ntot_amode)
  real(r8) :: tmp_nh4_aer(nstop, ntot_amode)
 real(r8) :: tmp_no3_aer(nstop, ntot_amode)
 real(r8) :: tmp_soa_aer(nstop, ntot_amode)
@@ -284,14 +284,14 @@ real(r8) :: tmp_bc_aer(nstop, ntot_amode)
 real(r8) :: tmp_dust_aer(nstop, ntot_amode)
 real(r8) :: tmp_co3_aer(nstop, ntot_amode)
 real(r8) :: tmp_nacl_aer(nstop, ntot_amode)
-real(r8) :: tmp_ca_aer(nstop, ntot_amode)                 
+real(r8) :: tmp_ca_aer(nstop, ntot_amode)
 real(r8) :: tmp_cl_aer(nstop, ntot_amode)
 real(r8) :: tmp_wat_aer(nstop, ntot_amode)
 real(r8) :: tmp_hygro_aer(nstop, ntot_amode)
 
 
 real(r8), dimension(nstop)            :: tmp_h2so4, tmp_hno3, tmp_nh3, &
-                                         tmp_soag, tmp_hcl, tmp_so2 ,tmp_relh, tmp_temp                                      
+                                         tmp_soag, tmp_hcl, tmp_so2 ,tmp_relh, tmp_temp
 real(r8), dimension(nstop,ntot_amode) :: qtend_cond_aging_so4, &
                                                qtend_cond_aging_soa, &
                                                qtend_rename_so4, &
@@ -309,15 +309,15 @@ real(r8), dimension(nstop,ntot_amode) :: qtend_cond_aging_so4, &
                                                qtend_coag_h2so4,       &
                                                qtend_coag_soag
 
-#if(defined USE_NC4)                                       
+#if(defined USE_NC4)
 !
 ! output comparison results
 !
-      ! Create the netCDF file. The nf90_clobber parameter tells 
+      ! Create the netCDF file. The nf90_clobber parameter tells
       ! netCDF to overwrite this file, if it already exists.
       call check( nf90_create(FILE_NAME, NF90_CLOBBER, ncid) )
 
-      ! Define the dimensions. NetCDF will hand back an ID for each. 
+      ! Define the dimensions. NetCDF will hand back an ID for each.
       call check( nf90_def_dim(ncid, "nsteps", nstop, nstep_dimid) )
       call check( nf90_def_dim(ncid, "mode", ntot_amode, mode_dimid) )
 
@@ -352,7 +352,7 @@ call check(nf90_def_var(ncid, "ca_aer", &
 call check(nf90_def_var(ncid, "cl_aer", &
           NF90_DOUBLE, dimids, varid(12)) )
 call check(nf90_def_var(ncid, "wat_aer", &
-          NF90_DOUBLE, dimids, varid(13)) )  
+          NF90_DOUBLE, dimids, varid(13)) )
 
 
 
@@ -470,7 +470,7 @@ call check(nf90_put_att(ncid, varid(23), "units", "K") )
       lmz_nh4_a2 = l_nh4_a2 - (imozart-1)
 
 
-main_time_loop:&  
+main_time_loop:&
 do nstep = 1, nstop
       istep = nstep
       if (nstep == 1) tnew = 0.0_r8
@@ -478,39 +478,39 @@ do nstep = 1, nstop
       tnew = told + deltat
 
       if (nstep == 1) then
-        temp = tmin 
+        temp = tmin
         relh = rhmin
-      end if         
-!      if (nstep > 1 .and. tmax > tmin ) then 
-      if (nstep > 1 ) then  
+      end if
+!      if (nstep > 1 .and. tmax > tmin ) then
+      if (nstep > 1 ) then
         temp = temp + (tmax -tmin)/(nstop -1)
         physta%t(1,1) = temp
-      end if 
+      end if
 !      if (nstep > 1 .and. rhmax > rhmin ) then
-      if (nstep > 1) then 
+      if (nstep > 1) then
         relh = relh + (rhmax -rhmin)/(nstop -1)
-       end if  
+       end if
 
        physta%t(:,:) = temp
        physta%relhum(:,:) = relh
        call  qsat( physta%t(1:pcols,1:pver), physta%pmid(1:pcols,1:pver), &
                   ev_sat(1:pcols,1:pver), qv_sat(1:pcols,1:pver) )
-       
+
        physta%qv(:,:) = physta%relhum(:,:)*qv_sat(:,:)
        physta%q(:,:,1) = physta%qv(:,:)
-        
+
 
       print*, 'T , H  !! ', physta%t, physta%q(:,:,1)
 !
 ! calcsize
 !
       write(*,'(/a,i8)') 'cambox_do_run doing calcsize, istep=', istep
-      print*, lchnk,pcols 
+      print*, lchnk,pcols
 
 ! *** new calcsize interface ***
 ! load state
       physta%lchnk = lchnk
-      physta%ncol  = pcols 
+      physta%ncol  = pcols
 
 ! load pbuf
       call load_pbuf( pbuf, lchnk, pcols, &
@@ -520,7 +520,7 @@ do nstep = 1, nstop
       ptend%q     = 0.
       call modal_aero_calcsize_sub( physta, ptend, deltat, pbuf, &
          do_adjust_in=.true., do_aitacc_transfer_in=.true. )
-      
+
 ! unload pbuf
       call unload_pbuf( pbuf, lchnk, pcols, &
          physta%cld, physta%qqcw, physta%dgncur_a, physta%dgncur_awet,  physta%qaerwat, physta%wetdens, physta%hygro )
@@ -644,8 +644,8 @@ IF (nstep > 1) then
       dvmrcwdt_rnam(:,:,:) = dvmrcwdt_bb(:,:,:,iqqcwtend_rnam)
       dvmrcwdt_nnuc(:,:,:) = 0.0_r8
       dvmrcwdt_coag(:,:,:) = 0.0_r8
-      
-END IF      
+
+END IF
 !
 ! done
 !
@@ -657,28 +657,28 @@ END IF
       loffset = imozart - 1
       do l = imozart, pcnst
          l2 = l - loffset
-         physta%q(    :,:,l)  = vmr(  :,:,l2) * adv_mass(l2)/mwdry 
+         physta%q(    :,:,l)  = vmr(  :,:,l2) * adv_mass(l2)/mwdry
          physta%qqcw( :,:,l)  = vmrcw(:,:,l2) * adv_mass(l2)/mwdry
       end do
 !
 ! store the data of each time step for netcdf output
 !
 
-      if (l_h2so4g > 0) tmp_h2so4 (nstep) = physta%q(1,1,l_h2so4g)* adv_mass(l_h2so4g-loffset)/mwdry *1E9               
-      if (l_hno3g > 0) tmp_hno3(nstep) = physta%q(1,1,l_hno3g)* adv_mass(l_hno3g-loffset)/mwdry *1E9 
-      if (l_nh3g > 0)  tmp_nh3(nstep)  = physta%q(1,1,l_nh3g)* adv_mass(l_nh3g-loffset)/mwdry *1E9 
-      if (l_soag > 0)  tmp_soag(nstep) = physta%q(1,1,l_soag)* adv_mass(l_soag-loffset)/mwdry *1E9 
-      if (l_hclg > 0)  tmp_hcl(nstep)  = physta%q(1,1,l_hclg)* adv_mass(l_hclg-loffset)/mwdry *1E9 
-      if (l_so2g > 0)  tmp_so2(nstep)  = physta%q(1,1,l_so2g) * adv_mass(l_so2g-loffset)/mwdry *1E9 
+      if (l_h2so4g > 0) tmp_h2so4 (nstep) = physta%q(1,1,l_h2so4g)* adv_mass(l_h2so4g-loffset)/mwdry *1E9
+      if (l_hno3g > 0) tmp_hno3(nstep) = physta%q(1,1,l_hno3g)* adv_mass(l_hno3g-loffset)/mwdry *1E9
+      if (l_nh3g > 0)  tmp_nh3(nstep)  = physta%q(1,1,l_nh3g)* adv_mass(l_nh3g-loffset)/mwdry *1E9
+      if (l_soag > 0)  tmp_soag(nstep) = physta%q(1,1,l_soag)* adv_mass(l_soag-loffset)/mwdry *1E9
+      if (l_hclg > 0)  tmp_hcl(nstep)  = physta%q(1,1,l_hclg)* adv_mass(l_hclg-loffset)/mwdry *1E9
+      if (l_so2g > 0)  tmp_so2(nstep)  = physta%q(1,1,l_so2g) * adv_mass(l_so2g-loffset)/mwdry *1E9
 
       tmp_dgn_a(nstep,1:ntot_amode)        = physta%dgncur_a(1,1,1:ntot_amode)
       tmp_dgn_awet(nstep,1:ntot_amode)     = physta%dgncur_awet(1,1,1:ntot_amode)
-      tmp_dgn_a(nstep,1:ntot_amode)  = tmp_dgn_awet(nstep,1:ntot_amode)  ! use wet in th output 
+      tmp_dgn_a(nstep,1:ntot_amode)  = tmp_dgn_awet(nstep,1:ntot_amode)  ! use wet in th output
 
       do i = 1, ntot_amode
        tmp_num_aer(nstep,i) = physta%q(1,1,numptr_amode(i))
        if(lptr_so4_a_amode(i)>0)  tmp_so4_aer(nstep,i) = physta%q(1,1,lptr_so4_a_amode(i))
-       if(lptr_nh4_a_amode(i)>0)  tmp_nh4_aer(nstep,i) = physta%q(1,1,lptr_nh4_a_amode(i)) 
+       if(lptr_nh4_a_amode(i)>0)  tmp_nh4_aer(nstep,i) = physta%q(1,1,lptr_nh4_a_amode(i))
        if(lptr_no3_a_amode(i)>0)  tmp_no3_aer(nstep,i) = physta%q(1,1,lptr_no3_a_amode(i))
        if(lptr_soa_a_amode(i)>0)  tmp_soa_aer(nstep,i) = physta%q(1,1,lptr_soa_a_amode(i))
        if(lptr_pom_a_amode(i)>0)  tmp_pom_aer(nstep,i) = physta%q(1,1,lptr_pom_a_amode(i))
@@ -694,7 +694,7 @@ END IF
 
        tmp_relh(nstep) = physta%relhum(1,1)
        tmp_temp(nstep) = physta%t(1,1)
-        
+
 end do main_time_loop
 
 #if (defined USE_NC4)
@@ -742,10 +742,10 @@ call check( nf90_put_var(ncid, varid(18), &
             tmp_hcl(1:nstop)) )
 call check( nf90_put_var(ncid, varid(19), &
             tmp_so2(1:nstop)) )
-    
-call check( nf90_put_var(ncid, varid(20), &    
-            tmp_dgn_a(1:nstop,1:ntot_amode)) )    
-    
+
+call check( nf90_put_var(ncid, varid(20), &
+            tmp_dgn_a(1:nstop,1:ntot_amode)) )
+
 call check( nf90_put_var(ncid, varid(21), &
             tmp_hygro_aer(1:nstop,1:ntot_amode)) )
 
@@ -754,7 +754,7 @@ call check( nf90_put_var(ncid, varid(22), &
 
 call check( nf90_put_var(ncid, varid(23), &
             tmp_temp(1:nstop)) )
-    
+
       ! Close the file. This frees up any internal netCDF resources
       ! associated with the file, and flushes any buffers.
       call check( nf90_close(ncid) )
@@ -842,7 +842,7 @@ call check( nf90_put_var(ncid, varid(23), &
          fldcw(1:ncol,:) = qqcw(1:ncol,:,l)
       end do
       end do
-   
+
       print*,'end pbuf'
       return
       end subroutine load_pbuf

--- a/src/gaschem_simple.F90
+++ b/src/gaschem_simple.F90
@@ -31,7 +31,7 @@ subroutine gaschem_simple_sub(                     &
 
 use mam_utils  ,       only:  iulog, pcols, pver, endrun
 use constituents,      only:  pcnst, cnst_name, cnst_get_ind
-                                                                                                                                            
+
 
 
 implicit none
@@ -50,7 +50,7 @@ implicit none
    real(r8), intent(inout) :: tau_gaschem_simple(ncol,pver)
                                                    ! like q but for cloud-borner tracers
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 ! computes TMR (tracer mixing ratio) tendencies for gas condensation
 !    onto aerosol particles
 !


### PR DESCRIPTION
Ok as promised the PR removing all white space. I can also only do it for the python and cmake files.

This should be merged first.

edit: done using:

```bash
find . -path "./.venv" -prune -o -name "*.txt" -exec sed --in-place 's/[[:space:]]\+$//' {} \+
find . -path "./.venv" -prune -o -name "*.py" -exec sed --in-place 's/[[:space:]]\+$//' {} \+
find . -path "./.venv" -prune -o -name "*.F90" -exec sed --in-place 's/[[:space:]]\+$//' {} \+
```

